### PR TITLE
Fix the OAUTH login

### DIFF
--- a/aksara/Modules/Auth/Controllers/Auth.php
+++ b/aksara/Modules/Auth/Controllers/Auth.php
@@ -497,7 +497,7 @@ class Auth extends \Aksara\Laboratory\Core
 				(
 					'email'							=> $session->email,
 					'password'						=> '',
-					'username'						=> '',
+					'username'						=> $session->oauth_uid,
 					'first_name'					=> $session->first_name,
 					'last_name'						=> $session->last_name,
 					'photo'							=> $photo,

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -49,7 +49,7 @@ Options All -Indexes
 	Header set X-Content-Type-Options "nosniff"
 	Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains"
 	Header set Referrer-Policy "same-origin"
-	Header set Feature-Policy "geolocation 'self'; vibrate 'none'"
+	Header set Feature-Policy "geolocation 'self'"
 </IfModule>
 
 # Disable server signature start


### PR DESCRIPTION
Fixing the OAUTH login that failing when create username;
Remove "vibrate" from CSP