### PR TITLE
Limit create, update and delete method

### DIFF
--- a/aksara/Laboratory/Core.php
+++ b/aksara/Laboratory/Core.php
@@ -2348,9 +2348,14 @@ class Core extends Controller
 		{
 			return throw_exception(403, phrase('the_method_you_requested_is_not_acceptable') . ' (' . service('request')->getServer('REQUEST_METHOD'). ')', (!$this->_api_request ? $this->_redirect_back : null));
 		}
-		else if($table && !$this->_set_permission && in_array($this->_method, array('create', 'update', 'delete')))
+		else if($table && !$this->_set_permission)
 		{
-			return throw_exception(403, phrase('the_method_you_requested_is_not_acceptable') . ' (' . strtoupper($this->_method). ')', (!$this->_api_request ? $this->_redirect_back : null));
+			$this->unset_action('create, update, delete');
+			
+			if(in_array($this->_method, array('create', 'update', 'delete')))
+			{
+				return throw_exception(403, phrase('the_method_you_requested_is_not_acceptable') . ' (' . strtoupper($this->_method). ')', (!$this->_api_request ? $this->_redirect_back : null));
+			}
 		}
 		
 		if(!$this->_table)


### PR DESCRIPTION
Limit create, update and delete method when permission isn't set to prevent hijacking content without permission.