### PR TITLE
Add ecosystem seeder install preparation

### DIFF
--- a/install/Controllers/Install.php
+++ b/install/Controllers/Install.php
@@ -457,6 +457,12 @@ class Install extends BaseController
                         if (session()->get('installation_mode') > 0) {
                             // Run seeder to insert sample data
                             $seeder->call('DummySeeder');
+
+                            // Run ecosystem seeder
+                            if (session()->get('installation_mode') > 1) {
+                                // Required by current ecosystem, suffixed with installation id
+                                $seeder->call('EcosystemSeeder_' . session()->get('installation_mode'));
+                            }
                         }
                     }
 


### PR DESCRIPTION
When you build your ecosystem using Aksara, you could add the object to the installation mode (under the "system" function inside a "Install" controller).
* The additional installation mode ID must be greater than 1;
* Add the database migration file, name it with anything greater than exists there (to be executed last);
* Add the database seeder file and name it with "`DummySeeder_2`", "`DummySeeder_3`" or any;
* The suffix number is represent the installation mode ID.