### PR TITLE
fix: [DEPRECATED] exit(): Passing null to parameter #1 ($status) of t…

### DIFF
--- a/aksara/Helpers/main_helper.php
+++ b/aksara/Helpers/main_helper.php
@@ -247,7 +247,8 @@ if (! function_exists('throw_exception')) {
             $target = $target ?: base_url();
 
             // Redirect to target
-            exit(header('Location: ' . $target));
+            header('Location: ' . $target);
+            exit;
         }
 
         // Logic for AJAX Request: Return JSON Response


### PR DESCRIPTION
…ype string|int