### PR TITLE
feat: persist user language preference in cookies to maintain selecti…

### DIFF
--- a/aksara/Laboratory/Core.php
+++ b/aksara/Laboratory/Core.php
@@ -6717,35 +6717,39 @@ abstract class Core extends Controller
      */
     private function _setLanguage(?string $languageId = null): void
     {
-        $appLanguage = get_setting('app_language');
+        helper('cookie');
 
-        if (get_setting('force_system_language') && ! get_userdata('is_logged')) {
-            $languageId = ($appLanguage > 0 ? $appLanguage : 1);
-
+        // Try to recover language from cookie if session is not set (e.g., after logout)
+        if (! $languageId && get_cookie('aksara_language')) {
+            $languageId = get_cookie('aksara_language');
             set_userdata('language_id', $languageId);
         }
 
         // Check if session language ID is not set.
-        if (! get_userdata('language_id') || ! $languageId) {
+        if (! $languageId) {
             // Determine Initial Fallback Language ID
             $appLanguage = get_setting('app_language');
-            $languageId = ($appLanguage > 0 ? $appLanguage : 1);
 
-            // Get browser accepted locales (e.g., "en-US,en;q=0.9,id;q=0.8").
-            $locales = explode(',', (Services::request()->getServer('HTTP_ACCEPT_LANGUAGE') ?: 'en-us'));
+            if (get_setting('force_system_language') && ! get_userdata('is_logged')) {
+                // Force system language if user hasn't explicitly chosen one
+                $languageId = ($appLanguage > 0 ? $appLanguage : 1);
+            } else {
+                // Get browser accepted locales (e.g., "en-US,en;q=0.9,id;q=0.8").
+                $locales = explode(',', (Services::request()->getServer('HTTP_ACCEPT_LANGUAGE') ?: 'en-us'));
+                $languages = $this->model->getWhere('app_languages', ['status' => 1])->result();
 
-            // Retrieve available and active languages from the database.
-            $languages = $this->model->getWhere('app_languages', ['status' => 1])->result();
+                $languageId = ($appLanguage > 0 ? $appLanguage : 1); // fallback
 
-            // Match Browser Locale to Available Languages
-            foreach ($languages as $language) {
-                $items = array_map('trim', explode(',', strtolower($language->locale))); // Available locales for this language
+                // Match Browser Locale to Available Languages
+                foreach ($languages as $language) {
+                    $items = array_map('trim', explode(',', strtolower($language->locale))); // Available locales for this language
 
-                foreach ($locales as $loc) {
-                    if (in_array(strtolower(trim($loc)), $items)) {
-                        $languageId = $language->id;
+                    foreach ($locales as $loc) {
+                        if (in_array(strtolower(trim($loc)), $items)) {
+                            $languageId = $language->id;
 
-                        break 2; // Found match, break both loops.
+                            break 2; // Found match, break both loops.
+                        }
                     }
                 }
             }
@@ -6753,6 +6757,9 @@ abstract class Core extends Controller
             // Store the determined language ID in the user session.
             set_userdata('language_id', $languageId);
         }
+
+        // Persist the active language to cookie to survive login/logout session wipes
+        set_cookie('aksara_language', $languageId, SESSION_EXPIRATION);
 
         // Get the language code (e.g., 'en', 'id') from the determined ID.
         $languageCode = $this->model->select('code')

--- a/aksara/Laboratory/Permission.php
+++ b/aksara/Laboratory/Permission.php
@@ -464,7 +464,6 @@ class Permission
      *
      * @param   string|null $path
      * @param   string      $method
-     * @param   mixed       $router
      * @return  string|null
      */
     private function _normalizePath($path = null, $method = '', $router = null)

--- a/aksara/Modules/Auth/Controllers/Auth.php
+++ b/aksara/Modules/Auth/Controllers/Auth.php
@@ -172,7 +172,7 @@ class Auth extends Core
                         'user_id' => $execute->user_id,
                         'username' => $execute->username,
                         'group_id' => $execute->group_id,
-                        'language_id' => $execute->language_id,
+                        'language_id' => (get_userdata('language_id') ? get_userdata('language_id') : $execute->language_id),
                         'year' => ($this->_getActiveYears() ? ($this->request->getPost('year') ? $this->request->getPost('year') : date('Y')) : null),
                         'session_generated' => time()
                     ]);
@@ -181,7 +181,8 @@ class Auth extends Core
                     $this->model->update(
                         'app_users',
                         [
-                            'last_login' => date('Y-m-d H:i:s')
+                            'last_login' => date('Y-m-d H:i:s'),
+                            'language_id' => (get_userdata('language_id') ? get_userdata('language_id') : $execute->language_id)
                         ],
                         [
                             'user_id' => $execute->user_id

--- a/aksara/Modules/Xhr/Controllers/Language.php
+++ b/aksara/Modules/Xhr/Controllers/Language.php
@@ -43,6 +43,9 @@ class Language extends Core
             set_userdata('language', $params);
             set_userdata('language_id', $query);
 
+            helper('cookie');
+            set_cookie('aksara_language', $query, SESSION_EXPIRATION);
+
             if (get_userdata('is_logged') && ! DEMO_MODE) {
                 $this->model->update('app_users', ['language_id' => $query], ['user_id' => get_userdata('user_id')]);
             }


### PR DESCRIPTION
…on across sessions

### Language Persistence Mechanism Update

The language handling in Aksara CMS has been updated to follow the **"Active Language Wins"** principle, ensuring seamless language persistence across sessions, logins, and logouts without disrupting the core `force_system_language` functionality.

**1. Initial Detection & Cookie Persistence**
When a new guest visits the site, the system determines the language based on either `force_system_language` (forcing the system default) or the browser's HTTP locale. Crucially, this initial assignment only occurs if the user hasn't already acquired a language session. The active language is then saved to a cookie bound by the `SESSION_EXPIRATION` config, ensuring the preference survives sudden session wipes.

**2. Synchronized Manual Overrides**
Whenever a user explicitly switches their language via the UI (XHR request), the system instantly synchronizes the change across three layers: the active session, the persistent cookie, and the `app_users` database profile (if they are logged in). This guarantees that manual overrides are robust and immediately respected system-wide.

**3. Seamless Authentication Lifecycle**
During the **login** process, the system actively prevents abrupt UI changes by taking the language currently active in the guest session and updating the user's database profile (`app_users.language_id`) to match it. Conversely, during **logout**—when the user's session is completely destroyed—the persistent cookie immediately kicks in to restore the active language, allowing the user to seamlessly continue browsing as a guest in their preferred language.