### PR TITLE
Upgrade Picqer barcode generator to v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "hybridauth/hybridauth": "^3.10",
         "mpdf/mpdf": "^8.0",
         "chillerlan/php-qrcode": "^3.3",
-        "picqer/php-barcode-generator": "^2.1",
+        "picqer/php-barcode-generator": "^3.2",
         "phpoffice/phpspreadsheet": "^2.2",
         "halaxa/json-machine": "^1.1",
         "phpoffice/phpword": "^1.4",


### PR DESCRIPTION
## Summary

- upgrade `picqer/php-barcode-generator` from `^2.1` to `^3.2`
- use the maintained major version now that Aksara requires PHP 8.2

The `BarcodeGeneratorPNG::getBarcode()` API used by `Miscellaneous::barcodeGenerator()` remains available in v3.

## Validation

- `composer validate --no-check-publish`
- `composer update --dry-run --no-interaction --no-scripts --no-progress` resolves `picqer/php-barcode-generator` v3.2.4
- verified the existing PNG generator call against v3.2.4