### PR TITLE
fix(core): resolve empty 404 response page and view helper config

### DIFF
--- a/aksara/Laboratory/Builder/Components/Core.php
+++ b/aksara/Laboratory/Builder/Components/Core.php
@@ -1313,7 +1313,7 @@ class Core
                             {{ phrase('The page you requested does not exist or has already been archived.') }}
                         </p>
                         <div class="text-center">
-                            <a href="{{ base_url() }}" class="btn btn-outline-primary rounded-pill px-4">
+                            <a href="{{ base_url() }}" class="btn btn-outline-primary rounded-pill px-4 --xhr">
                                 <i class="mdi mdi-arrow-left"></i>
                                 {{ phrase('Back to Homepage') }}
                             </a>

--- a/aksara/Modules/Pages/Controllers/Pages.php
+++ b/aksara/Modules/Pages/Controllers/Pages.php
@@ -33,54 +33,54 @@ class Pages extends Core
 
     public function index($slug = null)
     {
-        $this->setTitle('{{ page_title }}', phrase('Page not found!'))
-        ->setDescription('{{ page_description }}', phrase('The page you requested does not exist or has already been archived.'))
-        ->setIcon('mdi mdi-file-document-outline')
-        ->setOutput([
-            'suggestions' => $this->model->select('
-                page_slug,
-                page_title
-            ')
-            ->getWhere(
-                $this->_table,
-                [
-                    'status' => 1,
-                    'language_id' => get_userdata('language_id')
-                ],
-                8
-            )
-            ->result()
-        ])
-        ->groupStart()
-        ->where('pages.page_slug', $slug)
-        ->orWhere('pages.page_id', $this->request->getGet('page_id') ?? 0)
-        ->groupEnd()
-        ->where('status', 1)
-        ->orderBy('(CASE WHEN pages.language_id = ' . get_userdata('language_id') . ' THEN 1 ELSE 2 END)', 'ASC')
-        ->limit(1)
+        return $this->setTitle('{{ page_title }}', phrase('Page not found!'))
+            ->setDescription('{{ page_description }}', phrase('The page you requested does not exist or has already been archived.'))
+            ->setIcon('mdi mdi-file-document-outline')
+            ->setOutput([
+                'suggestions' => $this->model->select('
+                    page_slug,
+                    page_title
+                ')
+                ->getWhere(
+                    $this->_table,
+                    [
+                        'status' => 1,
+                        'language_id' => get_userdata('language_id')
+                    ],
+                    8
+                )
+                ->result()
+            ])
+            ->groupStart()
+            ->where('pages.page_slug', $slug)
+            ->orWhere('pages.page_id', $this->request->getGet('page_id') ?? 0)
+            ->groupEnd()
+            ->where('status', 1)
+            ->orderBy('(CASE WHEN pages.language_id = ' . get_userdata('language_id') . ' THEN 1 ELSE 2 END)', 'ASC')
+            ->limit(1)
 
-        ->render($this->_table, 'index');
+            ->render($this->_table, 'index');
     }
 
     public function notFound()
     {
-        $this->setTitle(phrase('Page not found!'))
-        ->setDescription(phrase('The page you requested does not exist or has already been archived.'))
-        ->setOutput([
-            'suggestions' => $this->model->select('
-                page_slug,
-                page_title
-            ')
-            ->getWhere(
-                $this->_table,
-                [
-                    'status' => 1
-                ],
-                8
-            )
-            ->result()
-        ])
-        ->setTemplate('index', '404')
-        ->render();
+        return $this->setTitle(phrase('Page not found!'))
+            ->setDescription(phrase('The page you requested does not exist or has already been archived.'))
+            ->setOutput([
+                'suggestions' => $this->model->select('
+                    page_slug,
+                    page_title
+                ')
+                ->getWhere(
+                    $this->_table,
+                    [
+                        'status' => 1
+                    ],
+                    8
+                )
+                ->result()
+            ])
+            ->setTemplate('index', '404')
+            ->render();
     }
 }

--- a/aksara/Views/templates/404.php
+++ b/aksara/Views/templates/404.php
@@ -22,8 +22,7 @@
         <div class="d-flex g-3 rounded-pill border border-light-subtle p-1">
             <div class="input-group ps-4">
                 <i class="mdi mdi-magnify mdi-2x text-muted"></i>
-                <input type="text" name="q" class="form-control form-control-lg fw-light border-0 bg-transparent" value="<?= htmlspecialchars(service('request')->getGet('q') ?? '') ?>" placeholder="<?= $searchLabel ??
-  phrase('Search something...') ?>">
+                <input type="text" name="q" class="form-control form-control-lg fw-light border-0 bg-transparent" value="<?= htmlspecialchars(service('request')->getGet('q') ?? '') ?>" placeholder="<?= $searchLabel ?? phrase('Search something...') ?>">
                 <button type="submit" class="btn btn-primary btn-lg fw-light rounded-pill px-4">
                     <?= phrase('Search') ?> <i class="mdi mdi-arrow-right"></i>
                 </button>


### PR DESCRIPTION
## Description
- Return Response object from Pages::notFound() and Pages::index() so CI4 404 override handler receives rendered output
- Change config('Views') to config('View') in view() helper with nullsafe property access

---

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] ♻️ Refactoring / Code cleanup (no logic/API breaking changes)
- [ ] 🌐 Translation / Localization update
- [ ] 📝 Documentation update

---

## Mandatory Checklist
Before submitting this Pull Request, please ensure you have completed the following steps:

- [x] **I have run `composer cs-fix` locally and confirmed that code formatting, view tags, and minified JS/CSS assets pass with 0 errors.**
- [x] My code follows the coding standards and guidelines of Aksara.
- [x] I have conducted a self-review of my changes.
- [x] I have tested the changes locally to verify functionality.
- [x] My changes generate no new warnings or errors.